### PR TITLE
fix: IDOR vulnerability — file serving endpoint lacks tenant ownership check

### DIFF
--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -9,6 +9,8 @@ import (
 	"github.com/vietbui/chat-quality-agent/api/handlers"
 	"github.com/vietbui/chat-quality-agent/api/middleware"
 	"github.com/vietbui/chat-quality-agent/config"
+	"github.com/vietbui/chat-quality-agent/db"
+	"github.com/vietbui/chat-quality-agent/db/models"
 	"github.com/vietbui/chat-quality-agent/mcp"
 )
 
@@ -37,7 +39,7 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		})
 	}
 
-	// Serve uploaded files (requires JWT auth)
+	// Serve uploaded files (requires JWT auth + tenant ownership)
 	r.GET("/api/v1/files/*filepath", middleware.JWTAuth(), func(c *gin.Context) {
 		fp := c.Param("filepath")
 		// Security: clean path and verify it stays within base directory
@@ -50,6 +52,21 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		// Verify resolved path is within base directory
 		if !strings.HasPrefix(fullPath, "/var/lib/cqa/files") {
 			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		// Security: verify user belongs to the tenant owning this file
+		// Path structure: /{tenantID}/{convID}/{filename}
+		pathParts := strings.SplitN(strings.TrimPrefix(cleanPath, "/"), "/", 3)
+		if len(pathParts) < 1 || pathParts[0] == "" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		fileTenantID := pathParts[0]
+		userID := middleware.GetUserID(c)
+		var count int64
+		db.DB.Model(&models.UserTenant{}).Where("user_id = ? AND tenant_id = ?", userID, fileTenantID).Count(&count)
+		if count == 0 {
+			c.JSON(http.StatusForbidden, gin.H{"error": "tenant_access_denied"})
 			return
 		}
 		c.File(fullPath)


### PR DESCRIPTION
## Description

The file serving endpoint `GET /api/v1/files/*filepath` in `backend/api/router.go` only requires JWT authentication and performs path traversal checks, but does NOT verify that the authenticated user belongs to the tenant that owns the requested file.

This is an **Insecure Direct Object Reference (IDOR)** vulnerability: any authenticated user can access files belonging to any tenant by guessing or enumerating the file path (which includes the tenant ID).

## Steps to Reproduce

1. Authenticate as a user belonging to tenant A
2. Request a file owned by tenant B: `GET /api/v1/files/tenantB-id/conv-id/file.pdf`
3. The file is served despite the user not having access to tenant B

## Expected Behavior

The endpoint should verify that the authenticated user is a member of the tenant ID embedded in the file path before serving the file.

## Fix

Extract the tenant ID from the file path, query `UserTenant` to verify the user belongs to that tenant, and return 403 if not.

## Affected File

- `backend/api/router.go`

## Severity

**High** — This is a data access control vulnerability that allows cross-tenant file access.

## Labels

bug, security