### PR TITLE
fix: token refresh race condition causes unexpected logouts

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -14,6 +14,9 @@ api.interceptors.request.use((config) => {
   return config
 })
 
+// Shared refresh promise to prevent multiple concurrent refresh calls
+let refreshPromise: Promise<string> | null = null
+
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -21,10 +24,20 @@ api.interceptors.response.use(
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true
       try {
-        // Refresh token sent automatically via HttpOnly cookie
-        const { data } = await axios.post('/api/v1/auth/refresh', {}, { withCredentials: true })
-        localStorage.setItem('cqa_access_token', data.access_token)
-        originalRequest.headers.Authorization = `Bearer ${data.access_token}`
+        // If a refresh is already in-flight, wait for it instead of firing another
+        if (!refreshPromise) {
+          refreshPromise = axios
+            .post('/api/v1/auth/refresh', {}, { withCredentials: true })
+            .then(({ data }) => {
+              localStorage.setItem('cqa_access_token', data.access_token)
+              return data.access_token
+            })
+            .finally(() => {
+              refreshPromise = null
+            })
+        }
+        const newToken = await refreshPromise
+        originalRequest.headers.Authorization = `Bearer ${newToken}`
         return api(originalRequest)
       } catch {
         localStorage.removeItem('cqa_access_token')


### PR DESCRIPTION
## Description

In `frontend/src/api/index.ts`, when multiple API requests receive 401 simultaneously, each request independently fires a token refresh call. This creates a race condition where:

1. Request A gets 401, starts refresh
2. Request B gets 401, starts a second refresh
3. Request A's refresh succeeds, stores new token
4. Request B's refresh fails (old refresh token already consumed), triggers logout

This causes users to be unexpectedly logged out during normal usage when multiple API calls happen concurrently.

## Steps to Reproduce

1. Open a page that fires multiple API calls simultaneously
2. Wait for the access token to expire
3. Observe that multiple refresh requests fire concurrently
4. User gets logged out unexpectedly

## Expected Behavior

Only one refresh request should be in-flight at a time. Subsequent 401s should wait for the existing refresh to complete and reuse the new token.

## Fix

Use a shared `refreshPromise` variable. If a refresh is already in-flight, subsequent requests await the same promise instead of firing new refresh calls.

## Affected File

- `frontend/src/api/index.ts`

## Labels

bug