### PR TITLE
fix: infinite polling loop in job run status check on frontend

### DIFF
--- a/frontend/src/views/Jobs/JobDetail.vue
+++ b/frontend/src/views/Jobs/JobDetail.vue
@@ -1005,11 +1005,14 @@ onMounted(async () => {
 })
 
 async function pollUntilComplete() {
-  while (true) {
+  let pollAttempts = 0
+  const maxPollAttempts = 120 // 6 minutes max for AI jobs
+  while (pollAttempts < maxPollAttempts) {
     await new Promise(r => setTimeout(r, 3000))
     await jobStore.fetchJobRuns(tenantId.value, jobId.value)
     const latestRun = jobStore.jobRuns[0]
     if (!latestRun || latestRun.status !== 'running') break
+    pollAttempts++
   }
   await jobStore.fetchAllJobResults(tenantId.value, jobId.value)
   job.value = await jobStore.fetchJob(tenantId.value, jobId.value)


### PR DESCRIPTION
## Description

In `frontend/src/views/Jobs/JobDetail.vue`, the `pollUntilComplete()` function uses a `while (true)` loop to poll job run status. If a job run never completes (e.g., backend crash, stuck AI provider), the frontend polls every 3 seconds indefinitely.

## Steps to Reproduce

1. Trigger a job run
2. If the backend hangs, the job run status stays at `running`
3. The frontend polls forever

## Expected Behavior

Polling should have a maximum number of attempts (e.g., 120 attempts = ~6 minutes for AI jobs). If exceeded, stop polling gracefully.

## Fix

Add a `maxPollAttempts` counter (120 attempts) to the polling loop.

## Affected File

- `frontend/src/views/Jobs/JobDetail.vue`