### PR TITLE
fix: infinite polling loop in channel sync status check on frontend

### DIFF
--- a/frontend/src/views/Channels/ChannelDetail.vue
+++ b/frontend/src/views/Channels/ChannelDetail.vue
@@ -232,11 +232,19 @@ async function doSync() {
   syncResult.value = null
   try {
     await channelStore.syncChannel(tenantId.value, channelId.value)
-    // Poll channel status until sync completes
-    while (true) {
+    // Poll channel status until sync completes (max 3 minutes)
+    let pollAttempts = 0
+    const maxPollAttempts = 60
+    while (pollAttempts < maxPollAttempts) {
       await new Promise(r => setTimeout(r, 3000))
       const ch = await channelStore.fetchChannel(tenantId.value, channelId.value)
       if (ch.last_sync_status !== 'syncing') break
+      pollAttempts++
+    }
+    if (pollAttempts >= maxPollAttempts) {
+      syncResult.value = { type: 'error', message: 'Đồng bộ quá lâu, vui lòng kiểm tra lại sau' }
+      syncing.value = false
+      return
     }
     await channelStore.fetchSyncHistory(tenantId.value, channelId.value, syncPage.value)
     const ch = channelStore.currentChannel


### PR DESCRIPTION
## Description

In `frontend/src/views/Channels/ChannelDetail.vue`, the `doSync()` function polls the channel sync status in a `while (true)` loop with no exit condition other than the status changing. If the backend never transitions out of the `syncing` state (e.g., due to a crash or error), the frontend will poll indefinitely, wasting network resources and keeping the UI in a loading state forever.

## Steps to Reproduce

1. Initiate a channel sync
2. If the backend hangs or crashes mid-sync, the status stays at `syncing`
3. The frontend polls every 3 seconds forever

## Expected Behavior

Polling should have a maximum number of attempts (e.g., 60 attempts = ~3 minutes). If exceeded, show an error message to the user.

## Fix

Add a `maxPollAttempts` counter. If polling exceeds the limit, display an error message and stop.

## Affected File

- `frontend/src/views/Channels/ChannelDetail.vue`