### PR TITLE
fix: OAuth state parameter not URL-encoded in auth code redirect

### DIFF
--- a/backend/mcp/oauth.go
+++ b/backend/mcp/oauth.go
@@ -10,6 +10,7 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -314,7 +315,7 @@ func issueAuthCode(c *gin.Context, client models.OAuthClient, userID, redirectUR
 	// Redirect back with auth code
 	redirectURL := fmt.Sprintf("%s?code=%s", redirectURI, code)
 	if state != "" {
-		redirectURL += "&state=" + state
+		redirectURL += "&state=" + url.QueryEscape(state)
 	}
 	c.Redirect(http.StatusFound, redirectURL)
 }


### PR DESCRIPTION
## Description

In `backend/mcp/oauth.go`, the OAuth `state` parameter is appended to the redirect URL as a raw string without URL encoding. If the state contains special characters (e.g., `+`, `=`, `&`, spaces), the redirect URL becomes malformed, breaking the OAuth flow or causing the client to misparse query parameters.

## Steps to Reproduce

1. Initiate an OAuth flow with a `state` parameter containing special characters (e.g., `state=foo+bar&baz`)
2. After authorization, observe the redirect URL has unencoded characters
3. The client fails to match the state or misparses the URL

## Expected Behavior

The `state` parameter should be URL-encoded with `url.QueryEscape()` before appending to the redirect URL.

## Fix

Use `url.QueryEscape(state)` when constructing the redirect URL.

## Affected File

- `backend/mcp/oauth.go`

## Labels

bug, security