### PR TITLE
fix: TriggerJob goroutine uses context.Background() with no timeout — resource leak

### DIFF
--- a/backend/api/handlers/jobs.go
+++ b/backend/api/handlers/jobs.go
@@ -307,7 +307,8 @@ func TriggerJob(c *gin.Context) {
 		}()
 		cfg, _ := config.Load()
 		analyzer := engine.NewAnalyzer(cfg)
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
 		var err error
 		switch mode {
 		case "unanalyzed":


### PR DESCRIPTION
## Description

In `backend/api/handlers/jobs.go`, the `TriggerJob` handler spawns a goroutine that calls the analyzer using `context.Background()`. Similar to TestRunJob, if the AI provider hangs, this goroutine will run indefinitely, leaking resources.

## Steps to Reproduce

1. Trigger a job via `TriggerJob` API
2. If the AI provider is unresponsive, the goroutine never exits
3. Accumulated leaked goroutines degrade server performance

## Expected Behavior

The goroutine should have a timeout (e.g., 30 minutes) to prevent indefinite execution.

## Fix

Replace `context.Background()` with `context.WithTimeout(context.Background(), 30*time.Minute)` and defer the cancel function.

## Affected File

- `backend/api/handlers/jobs.go` (TriggerJob)