### PR TITLE
fix: TestRunJob goroutine uses context.Background() with no timeout — resource leak

### DIFF
--- a/backend/api/handlers/jobs.go
+++ b/backend/api/handlers/jobs.go
@@ -260,7 +260,8 @@ func TestRunJob(c *gin.Context) {
 		}()
 		cfg, _ := config.Load()
 		analyzer := engine.NewAnalyzer(cfg)
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
 		if _, err := analyzer.RunJobWithLimit(ctx, job, 3); err != nil {
 			log.Printf("[test-run] error for job %s: %v", job.Name, err)
 		}


### PR DESCRIPTION
## Description

In `backend/api/handlers/jobs.go`, the `TestRunJob` handler spawns a goroutine that calls `analyzer.RunJobWithLimit()` using `context.Background()`. If the AI analysis hangs or the upstream provider is unresponsive, this goroutine will run indefinitely, leaking memory and goroutines over time.

## Steps to Reproduce

1. Trigger a test run via the API
2. If the AI provider hangs, the goroutine never exits
3. Repeated triggers accumulate leaked goroutines

## Expected Behavior

The goroutine should have a timeout (e.g., 30 minutes) so it self-terminates if the job takes too long.

## Fix

Replace `context.Background()` with `context.WithTimeout(context.Background(), 30*time.Minute)` and defer the cancel function.

## Affected File

- `backend/api/handlers/jobs.go` (TestRunJob)