### PR TITLE
fix: unbounded per_page parameter allows DB resource exhaustion in GetChannelSyncHistory

### DIFF
--- a/backend/api/handlers/channels.go
+++ b/backend/api/handlers/channels.go
@@ -836,6 +836,9 @@ func GetChannelSyncHistory(c *gin.Context) {
 	if page < 1 {
 		page = 1
 	}
+	if perPage < 1 || perPage > 100 {
+		perPage = 10
+	}
 
 	var total int64
 	db.DB.Model(&models.ActivityLog{}).


### PR DESCRIPTION
## Description

The `GetChannelSyncHistory` endpoint in `backend/api/handlers/channels.go` accepts a `per_page` query parameter without any upper-bound validation. A client can pass an arbitrarily large value (e.g., `per_page=999999`), causing the database to load massive result sets into memory, leading to resource exhaustion and potential denial of service.

## Steps to Reproduce

1. Call `GET /api/v1/tenants/:id/channels/:channelId/sync-history?per_page=999999`
2. Observe the database attempts to fetch all rows in a single query

## Expected Behavior

The `per_page` parameter should be capped to a reasonable maximum (e.g., 100) and default to a sensible value (e.g., 10) when out of range.

## Fix

Cap `per_page` to the range `[1, 100]`, defaulting to `10` when the value is out of bounds.

## Affected File

- `backend/api/handlers/channels.go`

## Labels

bug, security