### PR TITLE
fix: Facebook token handling while adding new fb page  

### DIFF
--- a/backend/api/handlers/channels.go
+++ b/backend/api/handlers/channels.go
@@ -108,25 +108,29 @@ func CreateChannel(c *gin.Context) {
 			AccessToken string `json:"access_token"`
 		}
 		if err := json.Unmarshal(req.Credentials, &fbCreds); err == nil && fbCreds.AccessToken != "" {
-			// Try to get Page Access Token from the provided token
-			pageID, pageToken, pageName, err := getFBPageToken(fbCreds.AccessToken)
-			if err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-				return
-			}
-			// Use the actual page token and page ID
-			fbCreds.PageID = pageID
-			fbCreds.AccessToken = pageToken
-			if pageName != "" {
-				channelName = pageName
-			}
-			externalID = pageID
+			if fbCreds.PageID != "" {
+				// Page Access Token provided directly — use as-is
+				externalID = fbCreds.PageID
+			} else {
+				// Only a user token provided — exchange for page token via /me/accounts
+				pageID, pageToken, pageName, err := getFBPageToken(fbCreds.AccessToken)
+				if err != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+					return
+				}
+				fbCreds.PageID = pageID
+				fbCreds.AccessToken = pageToken
+				if pageName != "" {
+					channelName = pageName
+				}
+				externalID = pageID
 
-			updatedCreds, _ := json.Marshal(fbCreds)
-			credentialsToStore, err = pkg.Encrypt(updatedCreds, cfg.EncryptionKey)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "encryption_failed"})
-				return
+				updatedCreds, _ := json.Marshal(fbCreds)
+				credentialsToStore, err = pkg.Encrypt(updatedCreds, cfg.EncryptionKey)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "encryption_failed"})
+					return
+				}
 			}
 		}
 	}
@@ -140,9 +144,14 @@ func CreateChannel(c *gin.Context) {
 		ExternalID:           externalID,
 		CredentialsEncrypted: credentialsToStore,
 		IsActive:             true,
-		Metadata:             func() string { if req.Metadata != "" { return req.Metadata }; return "{}" }(),
-		CreatedAt:            now,
-		UpdatedAt:            now,
+		Metadata: func() string {
+			if req.Metadata != "" {
+				return req.Metadata
+			}
+			return "{}"
+		}(),
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 
 	if err := db.DB.Create(&channel).Error; err != nil {
@@ -428,7 +437,7 @@ type zaloTokenResponse struct {
 	AccessToken  string          `json:"access_token"`
 	RefreshToken string          `json:"refresh_token"`
 	ExpiresIn    json.RawMessage `json:"expires_in"` // Zalo returns string or int
-	Error        json.RawMessage `json:"error"`       // can be int or string
+	Error        json.RawMessage `json:"error"`      // can be int or string
 	Message      string          `json:"message"`
 }
 
@@ -507,8 +516,8 @@ func fetchZaloOAInfo(accessToken string) (*zaloOAInfo, error) {
 		Error   int    `json:"error"`
 		Message string `json:"message"`
 		Data    struct {
-			OAID   string `json:"oa_id"`
-			Name   string `json:"name"`
+			OAID string `json:"oa_id"`
+			Name string `json:"name"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {

--- a/backend/api/handlers/facebook_test.go
+++ b/backend/api/handlers/facebook_test.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"os"
+	"testing"
+)
+
+// Integration tests for Facebook Graph API calls.
+// These tests hit the real Facebook API and require valid credentials.
+// Set the env vars below and remove t.Skip() to run them.
+//
+//   FB_PAGE_ID=<your_page_id> FB_PAGE_TOKEN=<your_page_access_token> \
+//   FB_USER_TOKEN=<your_user_access_token> \
+//   go test ./api/handlers/ -run TestFB -v
+
+func TestGetFBPageToken_WithUserToken(t *testing.T) {
+	t.Skip("integration test: set FB_USER_TOKEN and remove t.Skip() to run")
+
+	userToken := os.Getenv("FB_USER_TOKEN")
+	if userToken == "" {
+		t.Fatal("FB_USER_TOKEN env var required")
+	}
+
+	pageID, pageToken, pageName, err := getFBPageToken(userToken)
+	if err != nil {
+		t.Fatalf("getFBPageToken error: %v", err)
+	}
+	if pageID == "" {
+		t.Error("expected non-empty pageID")
+	}
+	if pageToken == "" {
+		t.Error("expected non-empty pageToken")
+	}
+	t.Logf("page_id=%s page_name=%s token_prefix=%s...", pageID, pageName, pageToken[:10])
+}
+
+func TestGetFBPageToken_WithPageAccessToken_ExpectsError(t *testing.T) {
+	t.Skip("integration test: set FB_PAGE_TOKEN and remove t.Skip() to run")
+
+	// A Page Access Token cannot call /me/accounts — FB returns OAuthException 102.
+	// This test documents and verifies that known failure so we handle it in CreateChannel.
+	pageToken := os.Getenv("FB_PAGE_TOKEN")
+	if pageToken == "" {
+		t.Fatal("FB_PAGE_TOKEN env var required")
+	}
+
+	_, _, _, err := getFBPageToken(pageToken)
+	if err == nil {
+		t.Error("expected error when passing a page access token to getFBPageToken (/me/accounts requires a user token)")
+	} else {
+		t.Logf("got expected error: %v", err)
+	}
+}
+
+func TestCreateChannel_DirectPageToken_UsesCredentialsAsIs(t *testing.T) {
+	t.Skip("integration test: set FB_PAGE_ID + FB_PAGE_TOKEN and remove t.Skip() to run")
+
+	// Verifies the fix: when page_id is provided alongside the access_token,
+	// CreateChannel must NOT call getFBPageToken — it should use them directly.
+	pageID := os.Getenv("FB_PAGE_ID")
+	pageToken := os.Getenv("FB_PAGE_TOKEN")
+	if pageID == "" || pageToken == "" {
+		t.Fatal("FB_PAGE_ID and FB_PAGE_TOKEN env vars required")
+	}
+
+	// Simulate the branching logic from CreateChannel
+	fbCreds := struct {
+		PageID      string
+		AccessToken string
+	}{PageID: pageID, AccessToken: pageToken}
+
+	externalID := ""
+	if fbCreds.AccessToken != "" {
+		if fbCreds.PageID != "" {
+			// Page token provided directly — use as-is, no API call
+			externalID = fbCreds.PageID
+		} else {
+			resolvedPageID, _, _, err := getFBPageToken(fbCreds.AccessToken)
+			if err != nil {
+				t.Fatalf("getFBPageToken: %v", err)
+			}
+			externalID = resolvedPageID
+		}
+	}
+
+	if externalID != pageID {
+		t.Errorf("externalID = %q, want %q", externalID, pageID)
+	}
+	t.Logf("externalID correctly set to %s without calling /me/accounts", externalID)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     build: .
     container_name: cqa-app
     restart: unless-stopped
-    expose:
-      - "8080"
+    ports:
+      - "8080:8080"
     env_file:
       - .env
     environment:


### PR DESCRIPTION

- Changed docker-compose.yml to map port 8080 instead of exposing it.
- Refactored CreateChannel function in channels.go to handle direct Page Access Tokens more efficiently.
- Added integration tests for Facebook Graph API interactions in facebook_test.go.

## Mô tả
Mô tả ngắn gọn thay đổi trong PR này.

## Loại thay đổi
- [x] Bug fix
- [x] Tính năng mới
- [ ] Cải thiện hiệu suất
- [ ] Tài liệu

## Kiểm tra
- [ ] Đã test trên local
- [ ] Đã chạy `docker compose up -d --build` thành công
